### PR TITLE
#202 - Update elastic search init container

### DIFF
--- a/data-portal/backend/docker-compose.yml
+++ b/data-portal/backend/docker-compose.yml
@@ -53,7 +53,7 @@ services:
         source: dataportal-elastic-data
         target: /usr/share/elasticsearch/data
   init-elasticsearch:
-    image: ghcr.io/medizininformatik-initiative/dataportal-es-init:2.0.0
+    image: ghcr.io/medizininformatik-initiative/dataportal-es-init:3.0.2
     depends_on:
       dataportal-elastic:
         condition: service_healthy


### PR DESCRIPTION
- update to 3.0.2
- main updates:
  - change workdir from /tmp to /work due to access right problems on some windows setups
  - adapt to new ontology zip file structure (but compatible to the old one)
  - create pipelines if present